### PR TITLE
RED-334: Replace TransactionBuilder with Psbt

### DIFF
--- a/packages/htlc/test/integration/networks/bitcoin/bitcoin-bip65.test.ts
+++ b/packages/htlc/test/integration/networks/bitcoin/bitcoin-bip65.test.ts
@@ -175,8 +175,9 @@ describe('UTXO BIP65 HTLC - Bitcoin Network', () => {
           feeTokensPerVirtualByte,
           refunder.privateKey,
         );
-        const refundTxId = await rpcClient.sendRawTransaction(refundTxHex);
-        expect(refundTxId).to.be.null;
+        await expect(
+          rpcClient.sendRawTransaction(refundTxHex),
+        ).to.be.rejectedWith(/locktime requirement not satisfied/);
       });
     });
 
@@ -217,8 +218,9 @@ describe('UTXO BIP65 HTLC - Bitcoin Network', () => {
           feeTokensPerVirtualByte,
           refunder.privateKey,
         );
-        const refundTxId = await rpcClient.sendRawTransaction(refundTxHex);
-        expect(refundTxId).to.be.null;
+        await expect(
+          rpcClient.sendRawTransaction(refundTxHex),
+        ).to.be.rejectedWith(/locktime requirement not satisfied/);
       });
     });
 

--- a/packages/htlc/test/integration/networks/bitcoin/bitcoin-bip65.test.ts
+++ b/packages/htlc/test/integration/networks/bitcoin/bitcoin-bip65.test.ts
@@ -1,6 +1,7 @@
 import {
   BitcoinSubnet,
   BlockResult,
+  FundTxOutput,
   Network,
   TxOutput,
 } from '@radar/redshift-types';
@@ -14,7 +15,7 @@ const { funder, claimer, refunder } = config.bitcoin.integration;
 const feeTokensPerVirtualByte = 1;
 let htlc: UtxoHtlc<Network.BITCOIN>;
 let rpcClient: UtxoRpcClient;
-let coinbaseUtxos: TxOutput[];
+let coinbaseUtxos: FundTxOutput[];
 let fundingUtxos: TxOutput[];
 let htlcArgs: UTXO.RedeemScriptArgs;
 let paymentSecret: string;
@@ -83,12 +84,17 @@ async function setCoinbaseUtxos() {
     coinbaseBlockHash,
   )) as BlockResult;
   const coinbaseTxId = coinbaseBlock.tx[0];
-  const coinbaseUtxo = await rpcClient.getTxOutput(coinbaseTxId, 0);
+  const [coinbaseUtxo, coinbaseTx] = await Promise.all([
+    rpcClient.getTxOutput(coinbaseTxId, 0),
+    rpcClient.getTransactionByHash(coinbaseTxId),
+  ]);
+
   coinbaseUtxos = [
     {
       txId: coinbaseTxId,
       index: 0,
       tokens: toSatoshi(coinbaseUtxo.value),
+      txHex: coinbaseTx.hex,
     },
   ];
 }

--- a/packages/htlc/test/integration/networks/bitcoin/bitcoin-bip68.test.ts
+++ b/packages/htlc/test/integration/networks/bitcoin/bitcoin-bip68.test.ts
@@ -191,7 +191,6 @@ describe('UTXO BIP68 HTLC - Bitcoin Network', () => {
     describe('P2PKH Address Refund Failure Case', async () => {
       setupTestSuite();
 
-      let refundTxId: string;
       it('should not allow a refund transaction if relative timelock hasnt elapsed', async () => {
         const currentBlockHeight = await rpcClient.getBlockCount();
         const refundTxHex = htlc.refund(
@@ -201,8 +200,11 @@ describe('UTXO BIP68 HTLC - Bitcoin Network', () => {
           feeTokensPerVirtualByte,
           refunder.privateKey,
         );
-        refundTxId = await rpcClient.sendRawTransaction(refundTxHex);
-        expect(refundTxId).to.be.null;
+        await expect(
+          rpcClient.sendRawTransaction(refundTxHex),
+        ).to.be.rejectedWith(
+          /TX rejected: transaction's sequence locks on inputs not met/,
+        );
       });
     });
 
@@ -234,7 +236,6 @@ describe('UTXO BIP68 HTLC - Bitcoin Network', () => {
     describe('P2WPKH Address Refund Failure Case', async () => {
       setupTestSuite(refunder.p2wpkhAddress);
 
-      let refundTxId: string;
       it('should not allow a refund transaction if relative timelock hasnt elapsed', async () => {
         const currentBlockHeight = await rpcClient.getBlockCount();
         const refundTxHex = htlc.refund(
@@ -244,8 +245,11 @@ describe('UTXO BIP68 HTLC - Bitcoin Network', () => {
           feeTokensPerVirtualByte,
           refunder.privateKey,
         );
-        refundTxId = await rpcClient.sendRawTransaction(refundTxHex);
-        expect(refundTxId).to.be.null;
+        await expect(
+          rpcClient.sendRawTransaction(refundTxHex),
+        ).to.be.rejectedWith(
+          /TX rejected: transaction's sequence locks on inputs not met/,
+        );
       });
     });
   });

--- a/packages/htlc/test/lib/helpers/rpc/rpc-call.ts
+++ b/packages/htlc/test/lib/helpers/rpc/rpc-call.ts
@@ -70,7 +70,10 @@ export async function postRpcCall(
         username: `${connectionConfig.username}`,
       },
     });
-    return resp.data;
+    if (resp.data.error) {
+      throw new Error(resp.data.error.message);
+    }
+    return resp.data.result;
   } catch (error) {
     throw new Error(`${NetworkError.RPC_CALL_FAILED}:${error}`);
   }

--- a/packages/htlc/test/lib/helpers/rpc/rpc-client.ts
+++ b/packages/htlc/test/lib/helpers/rpc/rpc-client.ts
@@ -20,8 +20,7 @@ export class UtxoRpcClient {
    * @return <Result Object>
    */
   public async getBlockCount(): Promise<number> {
-    return (await postRpcCall(this._network, this._subnet, 'getblockcount', []))
-      .result;
+    return postRpcCall(this._network, this._subnet, 'getblockcount', []);
   }
 
   /**
@@ -30,9 +29,7 @@ export class UtxoRpcClient {
    * @return <Result Object>
    */
   public async getBlockHash(height: number): Promise<string> {
-    return (await postRpcCall(this._network, this._subnet, 'getblockhash', [
-      height,
-    ])).result;
+    return postRpcCall(this._network, this._subnet, 'getblockhash', [height]);
   }
 
   /**
@@ -40,12 +37,7 @@ export class UtxoRpcClient {
    * @return <Result Object>
    */
   public async getBestBlockHash(): Promise<string> {
-    return (await postRpcCall(
-      this._network,
-      this._subnet,
-      'getbestblockhash',
-      [],
-    )).result;
+    return postRpcCall(this._network, this._subnet, 'getbestblockhash', []);
   }
 
   /**
@@ -58,10 +50,10 @@ export class UtxoRpcClient {
     hash: string,
     returnDecoded: boolean = true,
   ): Promise<BlockResult | string> {
-    return (await postRpcCall(this._network, this._subnet, 'getblock', [
+    return postRpcCall(this._network, this._subnet, 'getblock', [
       hash,
       returnDecoded,
-    ])).result;
+    ]);
   }
 
   /**
@@ -71,10 +63,7 @@ export class UtxoRpcClient {
    * @return <Result Object>
    */
   async getTxOutput(txId: string, vout: number): Promise<any> {
-    return (await postRpcCall(this._network, this._subnet, 'gettxout', [
-      txId,
-      vout,
-    ])).result;
+    return postRpcCall(this._network, this._subnet, 'gettxout', [txId, vout]);
   }
 
   /**
@@ -87,12 +76,10 @@ export class UtxoRpcClient {
     hash: string,
     returnDecoded: boolean = true,
   ): Promise<string | any> {
-    return (await postRpcCall(
-      this._network,
-      this._subnet,
-      'getrawtransaction',
-      [hash, returnDecoded ? 1 : 0],
-    )).result;
+    return postRpcCall(this._network, this._subnet, 'getrawtransaction', [
+      hash,
+      returnDecoded ? 1 : 0,
+    ]);
   }
 
   /**
@@ -101,11 +88,8 @@ export class UtxoRpcClient {
    * @return <Result Object>
    */
   public async sendRawTransaction(txHex: string): Promise<any> {
-    return (await postRpcCall(
-      this._network,
-      this._subnet,
-      'sendrawtransaction',
-      [txHex],
-    )).result;
+    return postRpcCall(this._network, this._subnet, 'sendrawtransaction', [
+      txHex,
+    ]);
   }
 }

--- a/packages/redshift-types/src/blockchain.ts
+++ b/packages/redshift-types/src/blockchain.ts
@@ -33,6 +33,12 @@ export interface TxOutput {
   tokens: number; // amount of tokens in this output
   address?: string; // output address
   script?: Buffer;
+  redeemScript?: Buffer;
+  witnessScript?: Buffer;
+}
+
+export interface FundTxOutput extends TxOutput {
+  txHex: string; // The hex encoded tx
 }
 
 export interface KeyPair {


### PR DESCRIPTION
## Description
Replace the `TransactionBuilder` class with `Psbt`. `TransactionBuilder` is deprecated and getting removed from bitcoinjs in the next major release.

## Checks
- [X] Tests were run locally
- [X] Please identify two developers to review this change
- [X] Linting was done locally
- [X] Code and unit of code written has an associated test
- [X] If readme needs to be updated to reflect this unit of work