### PR TITLE
Target correct redshift api urls

### DIFF
--- a/packages/redshift-api-client/src/clients/http-client.ts
+++ b/packages/redshift-api-client/src/clients/http-client.ts
@@ -15,7 +15,7 @@ import {
 import { validator } from '@radar/redshift-utils';
 import axios from 'axios';
 import sha256 from 'simple-sha256';
-import { config } from '../config';
+import { RedshiftApiUrl } from '../constants';
 
 export class HttpClient {
   private _apiBase: string;
@@ -24,7 +24,7 @@ export class HttpClient {
    * Instantiate the HTTP client
    * @param url The redshift API url without the path
    */
-  constructor(url: string = config.url) {
+  constructor(url: string = RedshiftApiUrl.MAINNET) {
     this._apiBase = `${url}/api`;
   }
 

--- a/packages/redshift-api-client/src/clients/redshift-client.ts
+++ b/packages/redshift-api-client/src/clients/redshift-client.ts
@@ -1,4 +1,4 @@
-import { config } from '../config';
+import { RedshiftApiUrl } from '../constants';
 import { HttpClient } from './http-client';
 import { WebSocketClient } from './websocket-client';
 
@@ -24,7 +24,7 @@ export class RedshiftClient {
    * Instantiate the REDSHIFT client
    * @param url The redshift WebSocket & HTTP API urls without the paths
    */
-  constructor(url: string = config.url) {
+  constructor(url: string = RedshiftApiUrl.MAINNET) {
     this._http = new HttpClient(url);
     this._ws = new WebSocketClient(url);
   }

--- a/packages/redshift-api-client/src/clients/websocket-client.ts
+++ b/packages/redshift-api-client/src/clients/websocket-client.ts
@@ -18,7 +18,7 @@ import {
 } from '@radar/redshift-types';
 import { validator } from '@radar/redshift-utils';
 import io from 'socket.io-client';
-import { config } from '../config';
+import { RedshiftApiUrl } from '../constants';
 
 export class WebSocketClient {
   private _url: string;
@@ -35,7 +35,7 @@ export class WebSocketClient {
    * Instantiate the WebSocket client
    * @param url The redshift WebSocket API url without the path
    */
-  constructor(url: string = config.url) {
+  constructor(url: string = RedshiftApiUrl.MAINNET) {
     this._url = `${url}/user/v1`;
   }
 

--- a/packages/redshift-api-client/src/config.ts
+++ b/packages/redshift-api-client/src/config.ts
@@ -1,3 +1,0 @@
-export const config = {
-  url: 'https://redshift.ion.radar.tech',
-};

--- a/packages/redshift-api-client/src/constants.ts
+++ b/packages/redshift-api-client/src/constants.ts
@@ -1,0 +1,7 @@
+/**
+ * REDSHIFT API testnet & mainnet URLs
+ */
+export enum RedshiftApiUrl {
+  TESTNET = 'https://api-testnet.redshift.radar.tech',
+  MAINNET = 'https://api.redshift.radar.tech',
+}

--- a/packages/redshift-api-client/src/index.ts
+++ b/packages/redshift-api-client/src/index.ts
@@ -1,1 +1,2 @@
 export { HttpClient, RedshiftClient, WebSocketClient } from './clients';
+export { RedshiftApiUrl } from './constants';

--- a/packages/redshift-api-client/test/http-client.test.ts
+++ b/packages/redshift-api-client/test/http-client.test.ts
@@ -2,7 +2,7 @@ import { ApiError, UserSwapState } from '@radar/redshift-types';
 import nock from 'nock';
 import sha256 from 'simple-sha256';
 import { HttpClient } from '../src';
-import { config } from '../src/config';
+import { RedshiftApiUrl } from '../src/constants';
 import { expect, fixtures } from './lib';
 
 describe('HTTP Client', () => {
@@ -13,7 +13,7 @@ describe('HTTP Client', () => {
 
   describe('getMarkets', () => {
     before(() => {
-      nock(`${config.url}/api`)
+      nock(`${RedshiftApiUrl.MAINNET}/api`)
         .get('/markets')
         .reply(200, fixtures.valid.markets.response);
     });
@@ -27,12 +27,12 @@ describe('HTTP Client', () => {
   describe('getMarketRequirements', () => {
     before(async () => {
       //  All market requirements
-      nock(`${config.url}/api`)
+      nock(`${RedshiftApiUrl.MAINNET}/api`)
         .get(`/markets/requirements`)
         .reply(200, fixtures.valid.allMarketRequirements.response);
 
       //  Single market requirements
-      nock(`${config.url}/api`)
+      nock(`${RedshiftApiUrl.MAINNET}/api`)
         .get(`/markets/${fixtures.valid.market}/requirements`)
         .reply(200, fixtures.valid.singleMarketRequirements.response);
     });
@@ -62,7 +62,7 @@ describe('HTTP Client', () => {
 
   describe('getOrders', () => {
     before(async () => {
-      nock(`${config.url}/api`)
+      nock(`${RedshiftApiUrl.MAINNET}/api`)
         .get('/orders')
         .query({ invoiceHash: await sha256(fixtures.valid.invoice) })
         .reply(200, fixtures.valid.orders.response);
@@ -82,7 +82,7 @@ describe('HTTP Client', () => {
 
   describe('getOrder', () => {
     before(async () => {
-      nock(`${config.url}/api`)
+      nock(`${RedshiftApiUrl.MAINNET}/api`)
         .get(`/orders/${fixtures.valid.orderId}`)
         .reply(200, fixtures.valid.order.response);
     });
@@ -101,7 +101,7 @@ describe('HTTP Client', () => {
 
   describe('getOrderState', () => {
     before(async () => {
-      nock(`${config.url}/api`)
+      nock(`${RedshiftApiUrl.MAINNET}/api`)
         .get(`/orders/${fixtures.valid.orderId}/state`)
         .reply(200, fixtures.valid.orderState.response);
     });
@@ -120,7 +120,7 @@ describe('HTTP Client', () => {
 
   describe('getOrderFundDetails', () => {
     before(async () => {
-      nock(`${config.url}/api`)
+      nock(`${RedshiftApiUrl.MAINNET}/api`)
         .get(`/orders/${fixtures.valid.orderId}/fundDetails`)
         .reply(200, fixtures.valid.orderFundDetails.response);
     });
@@ -139,7 +139,7 @@ describe('HTTP Client', () => {
 
   describe('getOrderTransactions', () => {
     before(async () => {
-      nock(`${config.url}/api`)
+      nock(`${RedshiftApiUrl.MAINNET}/api`)
         .get(`/orders/${fixtures.valid.orderId}/transactions`)
         .reply(200, fixtures.valid.orderTransactions.response);
     });
@@ -158,7 +158,7 @@ describe('HTTP Client', () => {
 
   describe('getOrderRefundDetails', () => {
     before(async () => {
-      nock(`${config.url}/api`)
+      nock(`${RedshiftApiUrl.MAINNET}/api`)
         .get(`/orders/${fixtures.valid.orderId}/refund`)
         .reply(200, fixtures.valid.orderRefund.response);
     });

--- a/packages/redshift-api-client/test/websocket-client.test.ts
+++ b/packages/redshift-api-client/test/websocket-client.test.ts
@@ -11,7 +11,7 @@ import fixtureSocket from 'can-fixture-socket';
 import sinon from 'sinon';
 import io from 'socket.io-client';
 import { WebSocketClient } from '../src';
-import { config } from '../src/config';
+import { RedshiftApiUrl } from '../src/constants';
 import { expect, fixtures } from './lib';
 
 describe('WebSocket Client', () => {
@@ -23,7 +23,7 @@ describe('WebSocket Client', () => {
     client = new WebSocketClient();
     server = new fixtureSocket.Server(io);
 
-    socket = io(config.url);
+    socket = io(RedshiftApiUrl.MAINNET);
     socketStub = sinon.stub(client, '_socket' as any).get(() => {
       return socket;
     });

--- a/packages/redshift.js/src/index.ts
+++ b/packages/redshift.js/src/index.ts
@@ -1,6 +1,7 @@
 export {
   HttpClient,
   RedshiftClient,
+  RedshiftApiUrl,
   WebSocketClient,
 } from '@radar/redshift-api-client';
 export * from '@radar/redshift-types';


### PR DESCRIPTION
## Description
This PR updates and exports the redshift api urls from `@radar/redshift-api-client` and `@radar/redshift.js`.

## Checks
- [X] Tests were run locally
- [X] Please identify two developers to review this change
- [X] Linting was done locally
- [X] Code and unit of code written has an associated test
- [X] If readme needs to be updated to reflect this unit of work