### PR TITLE
Widen unit conversion param types

### DIFF
--- a/packages/redshift-utils/src/numeric.ts
+++ b/packages/redshift-utils/src/numeric.ts
@@ -27,10 +27,12 @@ export function toHexString(number: BigNumber): string {
  * @param decimals The number of decimal places the unit amount has.
  */
 export function toBaseUnitAmount(
-  unitAmount: BigNumber,
-  decimals: BigNumber,
+  unitAmount: BigNumber | string | number,
+  decimals: BigNumber | string | number,
 ): BigNumber {
-  const baseUnitAmount = unitAmount.times(new BigNumber(ten).pow(decimals));
+  const baseUnitAmount = new BigNumber(unitAmount).times(
+    new BigNumber(ten).pow(decimals),
+  );
   if (baseUnitAmount.decimalPlaces() !== 0) {
     throw new Error(
       `Invalid unit amount: ${unitAmount.toString()} - Too many decimal places`,
@@ -46,10 +48,10 @@ export function toBaseUnitAmount(
  * @param decimals The number of decimal places the unit amount has.
  */
 export function toUnitAmount(
-  baseUnits: BigNumber,
-  decimals: BigNumber,
+  baseUnits: BigNumber | string | number,
+  decimals: BigNumber | string | number,
 ): BigNumber {
-  return baseUnits.div(new BigNumber(ten).pow(decimals));
+  return new BigNumber(baseUnits).div(new BigNumber(ten).pow(decimals));
 }
 
 /**


### PR DESCRIPTION
## Description
Widen the `toBaseUnitAmount` and `toUnitAmount` param types. It's unnecessary to force the caller to pass in a `BigNumber` object.

## Checks
- [X] Tests were run locally
- [X] Please identify two developers to review this change
- [X] Linting was done locally
- [X] Code and unit of code written has an associated test
- [X] If readme needs to be updated to reflect this unit of work