### PR TITLE
Add asset utilities to redshift-utils package

### DIFF
--- a/packages/redshift-utils/src/asset.ts
+++ b/packages/redshift-utils/src/asset.ts
@@ -1,0 +1,131 @@
+import { Market, Network, OnChainTicker, Subnet } from '@radar/redshift-types';
+import { AssetError } from './types';
+import { validator } from './validator';
+
+export const asset = {
+  /**
+   * Get the on-chain ticker for the provided market
+   * @param market The market
+   */
+  getOnchainTicker(market: Market): OnChainTicker {
+    if (!validator.isValidMarket(market)) {
+      throw new Error(AssetError.INVALID_MARKET);
+    }
+    return OnChainTicker[market.split('_')[0]];
+  },
+
+  /**
+   * Get the network and subnet for the passed on-chain asset
+   * @param value The on-chain ticker or market
+   */
+  getNetworkDetails(
+    value: OnChainTicker | Market,
+  ): { network: Network; subnet: Subnet } | undefined {
+    let ticker = value;
+    if (validator.isValidMarket(value)) {
+      ticker = asset.getOnchainTicker(value);
+    }
+    switch (ticker) {
+      case OnChainTicker.SBTC:
+        return {
+          network: Network.BITCOIN,
+          subnet: Subnet.SIMNET,
+        };
+      case OnChainTicker.TBTC:
+        return {
+          network: Network.BITCOIN,
+          subnet: Subnet.TESTNET,
+        };
+      case OnChainTicker.BTC:
+        return {
+          network: Network.BITCOIN,
+          subnet: Subnet.MAINNET,
+        };
+      case OnChainTicker.SLTC:
+        return {
+          network: Network.LITECOIN,
+          subnet: Subnet.SIMNET,
+        };
+      case OnChainTicker.TLTC:
+        return {
+          network: Network.LITECOIN,
+          subnet: Subnet.TESTNET,
+        };
+      case OnChainTicker.LTC:
+        return {
+          network: Network.LITECOIN,
+          subnet: Subnet.MAINNET,
+        };
+      case OnChainTicker.SXLM:
+        return {
+          network: Network.STELLAR,
+          subnet: Subnet.SIMNET,
+        };
+      case OnChainTicker.TXLM:
+        return {
+          network: Network.STELLAR,
+          subnet: Subnet.TESTNET,
+        };
+      case OnChainTicker.XLM:
+        return {
+          network: Network.STELLAR,
+          subnet: Subnet.MAINNET,
+        };
+      case OnChainTicker.SETH:
+      case OnChainTicker.SDAI:
+      case OnChainTicker.SUSDC:
+        return {
+          network: Network.ETHEREUM,
+          subnet: Subnet.GANACHE_SIMNET,
+        };
+      case OnChainTicker.KETH:
+      case OnChainTicker.KDAI:
+      case OnChainTicker.KUSDC:
+        return {
+          network: Network.ETHEREUM,
+          subnet: Subnet.KOVAN_TESTNET,
+        };
+      case OnChainTicker.ETH:
+      case OnChainTicker.DAI:
+      case OnChainTicker.USDC:
+        return {
+          network: Network.ETHEREUM,
+          subnet: Subnet.MAINNET,
+        };
+      default:
+        throw new Error(AssetError.INVALID_MARKET_OR_TICKER);
+    }
+  },
+
+  /**
+   * Get the mainnet ticker for the passed asset
+   * @param ticker The testnet or mainnet ticker
+   */
+  getMainnetTicker(ticker: OnChainTicker) {
+    if (/BTC/.test(ticker)) {
+      return OnChainTicker.BTC;
+    }
+    if (/ETH/.test(ticker)) {
+      return OnChainTicker.ETH;
+    }
+    if (/LTC/.test(ticker)) {
+      return OnChainTicker.LTC;
+    }
+    if (/ETH/.test(ticker)) {
+      return OnChainTicker.ETH;
+    }
+    if (/DAI/.test(ticker)) {
+      return OnChainTicker.DAI;
+    }
+    if (/USDC/.test(ticker)) {
+      return OnChainTicker.USDC;
+    }
+    if (/XLM/.test(ticker)) {
+      return OnChainTicker.XLM;
+    }
+    if (/DCR/.test(ticker)) {
+      return OnChainTicker.DCR;
+    }
+    throw new Error(AssetError.INVALID_TICKER);
+  },
+};

--- a/packages/redshift-utils/src/index.ts
+++ b/packages/redshift-utils/src/index.ts
@@ -1,3 +1,4 @@
+export * from './asset';
 export * from './format';
 export * from './numeric';
 export * from './rpc';

--- a/packages/redshift-utils/src/types.ts
+++ b/packages/redshift-utils/src/types.ts
@@ -1,0 +1,5 @@
+export enum AssetError {
+  INVALID_MARKET = 'InvalidMarket',
+  INVALID_TICKER = 'InvalidTicker',
+  INVALID_MARKET_OR_TICKER = 'InvalidMarketOrTicker',
+}

--- a/packages/redshift-utils/test/asset.test.ts
+++ b/packages/redshift-utils/test/asset.test.ts
@@ -1,0 +1,59 @@
+import { asset } from '../src';
+import { AssetError } from '../src/types';
+import { expect, fixtures } from './lib';
+
+describe('asset', () => {
+  describe('getOnchainTicker', () => {
+    it('should return the on-chain ticker if the market is valid', () => {
+      expect(asset.getOnchainTicker(fixtures.valid.market)).to.equal(
+        fixtures.valid.onchainTicker,
+      );
+    });
+
+    it('should throw an INVALID_MARKET error if the market is not valid', () => {
+      expect(() => asset.getOnchainTicker(fixtures.invalid.market)).to.throw(
+        Error,
+        AssetError.INVALID_MARKET,
+      );
+    });
+  });
+
+  describe('getNetworkDetails', () => {
+    it('should return the network details if a valid on-chain ticker is provided', () => {
+      expect(
+        asset.getNetworkDetails(fixtures.valid.onchainTicker),
+      ).to.deep.equal({
+        network: fixtures.valid.network,
+        subnet: fixtures.valid.subnet,
+      });
+    });
+
+    it('should return the network details if a valid market is provided', () => {
+      expect(asset.getNetworkDetails(fixtures.valid.market)).to.deep.equal({
+        network: fixtures.valid.network,
+        subnet: fixtures.valid.subnet,
+      });
+    });
+
+    it('should throw an INVALID_MARKET_OR_TICKER error if the param is not valid', () => {
+      expect(() => asset.getNetworkDetails(fixtures.invalid.market)).to.throw(
+        Error,
+        AssetError.INVALID_MARKET_OR_TICKER,
+      );
+    });
+  });
+
+  describe('getMainnetTicker', () => {
+    it('should return the mainnet on-chain ticker if the ticker is valid', () => {
+      expect(asset.getMainnetTicker(fixtures.valid.onchainTicker)).to.equal(
+        fixtures.valid.onchainTicker,
+      );
+    });
+
+    it('should throw an INVALID_TICKER error if the on-chain ticker is not valid', () => {
+      expect(() =>
+        asset.getMainnetTicker(fixtures.invalid.onchainTicker),
+      ).to.throw(Error, AssetError.INVALID_TICKER);
+    });
+  });
+});

--- a/packages/redshift-utils/test/lib/fixtures.ts
+++ b/packages/redshift-utils/test/lib/fixtures.ts
@@ -1,9 +1,15 @@
-import { Market, Network, OnChainTicker, Subnet } from '@radar/redshift-types';
+import {
+  MainnetOnChainTicker,
+  Market,
+  Network,
+  OnChainTicker,
+  Subnet,
+} from '@radar/redshift-types';
 
 export const fixtures = {
   valid: {
     network: Network.BITCOIN,
-    subnet: Subnet.SIMNET,
+    subnet: Subnet.MAINNET,
     onchainTicker: OnChainTicker.BTC,
     mainnetOnchainTicker: OnChainTicker.BTC,
     market: Market.BTC_LBTC,
@@ -13,11 +19,11 @@ export const fixtures = {
     hex: '0xdeadbeef',
   },
   invalid: {
-    network: 'invalid_network',
-    subnet: 'invalid_subnet',
-    onchainTicker: 'invalid_onchain_ticker',
-    mainnetOnchainTicker: 'invalid_mainnet_onchain_ticker',
-    market: 'invalid_market',
+    network: 'invalid_network' as Network,
+    subnet: 'invalid_subnet' as Subnet,
+    onchainTicker: 'invalid_onchain_ticker' as OnChainTicker,
+    mainnetOnchainTicker: 'invalid_mainnet_onchain_ticker' as MainnetOnChainTicker,
+    market: 'invalid_market' as Market,
     uuid: 'invalid_uuid',
     base58Check: 'invalid_base58',
     bech32: 'invalid_bech32',


### PR DESCRIPTION
## Description
This PR adds asset utilities to the `redshift-utils` package so they can be updated at the same time a new market is being added to the types package.

## Checks
- [X] Tests were run locally
- [X] Please identify two developers to review this change
- [X] Linting was done locally
- [X] Code and unit of code written has an associated test
- [X] If readme needs to be updated to reflect this unit of work