### PR TITLE
ERC20 Claim & EVM HTLC Test Fixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,9 @@ jobs:
         node-version: "8.12"
     - run: 
         name: Setup Integration Environment
-        command: docker-compose up -d
+        command: |
+          source ~/.bashrc
+          scripts/simnet-setup.sh ci
     - run:
         name: Build Packages
         command: |

--- a/README.md
+++ b/README.md
@@ -58,9 +58,9 @@ yarn
 yarn build
 ```
 
-### Start simnet services for tests 
+### Start simnet services & deploy contracts for tests
 ```sh
-docker-compose up -d
+scripts/simnet-setup.sh
 ```
 
 ### Run tests

--- a/packages/htlc/src/network-models/evm/contract-artifacts/ApproveAndCallFallBack.json
+++ b/packages/htlc/src/network-models/evm/contract-artifacts/ApproveAndCallFallBack.json
@@ -36,7 +36,6 @@
     "version": "0.5.8+commit.23d335f2.Emscripten.clang"
   },
   "networks": {},
-  "updatedAt": "2019-12-16T21:47:21.557Z",
   "schemaVersion": "3.0.14",
   "userdoc": {
     "methods": {}

--- a/packages/htlc/src/network-models/evm/contract-artifacts/Dummy18DecimalERC20Token.json
+++ b/packages/htlc/src/network-models/evm/contract-artifacts/Dummy18DecimalERC20Token.json
@@ -354,7 +354,6 @@
     "version": "0.5.8+commit.23d335f2.Emscripten.clang"
   },
   "networks": {},
-  "updatedAt": "2019-12-16T21:47:21.566Z",
   "schemaVersion": "3.0.14",
   "userdoc": {
     "methods": {}

--- a/packages/htlc/src/network-models/evm/contract-artifacts/Dummy6DecimalERC20Token.json
+++ b/packages/htlc/src/network-models/evm/contract-artifacts/Dummy6DecimalERC20Token.json
@@ -354,7 +354,6 @@
     "version": "0.5.8+commit.23d335f2.Emscripten.clang"
   },
   "networks": {},
-  "updatedAt": "2019-12-16T21:47:21.579Z",
   "schemaVersion": "3.0.14",
   "userdoc": {
     "methods": {}

--- a/packages/htlc/src/network-models/evm/contract-artifacts/ERC20Interface.json
+++ b/packages/htlc/src/network-models/evm/contract-artifacts/ERC20Interface.json
@@ -183,7 +183,6 @@
     "version": "0.5.8+commit.23d335f2.Emscripten.clang"
   },
   "networks": {},
-  "updatedAt": "2019-12-16T21:47:21.572Z",
   "schemaVersion": "3.0.14",
   "userdoc": {
     "methods": {}

--- a/packages/htlc/src/network-models/evm/contract-artifacts/ERC20Swap.json
+++ b/packages/htlc/src/network-models/evm/contract-artifacts/ERC20Swap.json
@@ -439,7 +439,6 @@
       "transactionHash": "0xc3dd6df90167d583fc2980556759a3dee5cf0e2f32959ec0f3d190f3c56ddb32"
     }
   },
-  "updatedAt": "2019-12-16T21:47:21.587Z",
   "schemaVersion": "3.0.14",
   "userdoc": {
     "methods": {

--- a/packages/htlc/src/network-models/evm/contract-artifacts/EtherSwap.json
+++ b/packages/htlc/src/network-models/evm/contract-artifacts/EtherSwap.json
@@ -290,7 +290,6 @@
       "transactionHash": "0xd6826014326f33a332f8d89f124316d637c04e37f3e56d53e350fd3ba77bacd5"
     }
   },
-  "updatedAt": "2019-12-16T21:47:21.591Z",
   "schemaVersion": "3.0.14",
   "userdoc": {
     "methods": {

--- a/packages/htlc/src/network-models/evm/contract-artifacts/Migrations.json
+++ b/packages/htlc/src/network-models/evm/contract-artifacts/Migrations.json
@@ -85,7 +85,6 @@
       "transactionHash": "0xcc408e21cf063bab8c5558d8e8b2ba890e6aa933d298b57daf7a73f08d8ce525"
     }
   },
-  "updatedAt": "2019-12-16T21:47:21.594Z",
   "schemaVersion": "3.0.14",
   "userdoc": {
     "methods": {}

--- a/packages/htlc/src/network-models/evm/contract-artifacts/Owned.json
+++ b/packages/htlc/src/network-models/evm/contract-artifacts/Owned.json
@@ -44,7 +44,6 @@
     "version": "0.5.8+commit.23d335f2.Emscripten.clang"
   },
   "networks": {},
-  "updatedAt": "2019-12-16T21:47:21.573Z",
   "schemaVersion": "3.0.14",
   "userdoc": {
     "methods": {

--- a/packages/htlc/src/network-models/evm/contract-artifacts/SafeMath.json
+++ b/packages/htlc/src/network-models/evm/contract-artifacts/SafeMath.json
@@ -9,7 +9,6 @@
     "version": "0.5.8+commit.23d335f2.Emscripten.clang"
   },
   "networks": {},
-  "updatedAt": "2019-12-16T21:47:21.574Z",
   "schemaVersion": "3.0.14",
   "userdoc": {
     "methods": {}

--- a/packages/htlc/src/network-models/evm/contract-artifacts/Swap.json
+++ b/packages/htlc/src/network-models/evm/contract-artifacts/Swap.json
@@ -66,7 +66,6 @@
     "version": "0.5.8+commit.23d335f2.Emscripten.clang"
   },
   "networks": {},
-  "updatedAt": "2019-12-16T21:47:21.595Z",
   "schemaVersion": "3.0.14",
   "userdoc": {
     "methods": {

--- a/packages/htlc/src/network-models/evm/contracts/scripts/trim-artifacts.js
+++ b/packages/htlc/src/network-models/evm/contracts/scripts/trim-artifacts.js
@@ -16,7 +16,6 @@ glob.sync( '../contract-artifacts/**/*.json' ).forEach(relativePath => {
     deployedBytecode,
     source,
     compiler,
-    updatedAt,
     schemaVersion,
     userdoc,
   } = artifact;
@@ -34,7 +33,6 @@ glob.sync( '../contract-artifacts/**/*.json' ).forEach(relativePath => {
     source,
     compiler,
     networks,
-    updatedAt,
     schemaVersion,
     userdoc
   };

--- a/packages/htlc/src/network-models/evm/evm-htlc.ts
+++ b/packages/htlc/src/network-models/evm/evm-htlc.ts
@@ -187,7 +187,7 @@ export class EvmHtlc<
       case EVM.AssetType.ERC20:
         const erc20MethodArgs = abi
           .simpleEncode(
-            'claim(bytes16,bytes32,bytes32)',
+            'claim(bytes16,address,bytes32)',
             this._orderUUID,
             this._tokenContractAddress,
             format.addHexPrefix(paymentSecret),

--- a/scripts/simnet-setup.sh
+++ b/scripts/simnet-setup.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -e
+
+# Start containers
+docker-compose up -d test-btcd test-btcctl test-ganache test-stellar
+
+# Deploy ethereum swap contracts
+cd packages/htlc/src/network-models/evm/contracts
+yarn && yarn deploy && yarn trim-artifacts


### PR DESCRIPTION
## Description
This PR contains two bug fixes:
* Fix ERC20 claim input data encoding. The `address` type must be used for the `tokenContractAddress` param. Previously we were using `bytes32`.
* The Ethereum simnet contracts were not being deployed for the tests, which meant that all test calls would succeed without actually testing the contract code. This is why the first bug was not caught.


## Checks
- [X] Tests were run locally
- [X] Please identify two developers to review this change
- [X] Linting was done locally
- [X] Code and unit of code written has an associated test
- [X] If readme needs to be updated to reflect this unit of work